### PR TITLE
Fix errors in BlocklyComponent

### DIFF
--- a/src/components/BlocklyComponent.jsx
+++ b/src/components/BlocklyComponent.jsx
@@ -16,8 +16,8 @@ import { Text } from './BlockCategories/Text';
 import { Variables } from './BlockCategories/Variables';
 import { Events } from './BlockCategories/Events';
 import { InputOutput } from './BlockCategories/InputOutput';
-import { Operators } from './BlockCategories/Operators';
-import { generateCode } from '../features/codeSlice'; // Make sure to import the correct action
+// import { Operators } from './BlockCategories/Operators';
+// import { generateCode } from '../features/codeSlice'; // Make sure to import the correct action
 
 import initializeBlockly from './InitializeBlockly';  // import the function
 import { javascriptGenerator } from 'blockly/javascript';
@@ -133,7 +133,6 @@ const BlocklyComponent = () => {
           ${Math}
           ${Text}
           ${Variables}
-          ${Operators}
           ${Events}
           ${Motion}
           ${Control}


### PR DESCRIPTION
The PR for implementation of Operator block isn't merged yet. They should be included in the toolbox only after the logic is merged. Commented out the usages for now.